### PR TITLE
Fix overlapping of level mapping boxes

### DIFF
--- a/src/app/Components/Table.tsx
+++ b/src/app/Components/Table.tsx
@@ -219,10 +219,7 @@ export default function Table({
         </h3>
         {/* Grid layout that creates columns for each factor */}
         <div
-          className="grid gap-6 overflow-x-auto"
-          style={{
-            gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
-          }}
+          className="grid gap-6 w-full grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
         >
           {headerNames.map((headerName, columnIndex) => (
             // Creates a section for each column/factor


### PR DESCRIPTION
## Summary
- adjust grid layout for level name customization boxes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532b5055248325838136a1b32b113c